### PR TITLE
Wrong normal calculation for Shared Coordinates

### DIFF
--- a/Source/DataGenerator.cs
+++ b/Source/DataGenerator.cs
@@ -491,7 +491,8 @@ namespace BIM.STLExport
                                 xyz[3 * n + 2] = z;
                             }
 
-                            triPnts[n] = point;
+                            var mypoint = new XYZ(xyz[3 * n], xyz[3 * n + 1], xyz[3 * n + 2]);
+                            triPnts[n] = mypoint;
                         }
 
                         Autodesk.Revit.DB.XYZ pnt1 = triPnts[1] - triPnts[0];


### PR DESCRIPTION
In DataGenerator.cs the normals are always generated for the initially obtained vertex.
When the project base point for the model has been modified with an angle to true north !=0, and you export with shared coordinates, the resulting normal value is incorrect.